### PR TITLE
add .DS_STORE to .gitignore to help OSX developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 client/server
 .vscode-test
 *.vsix
+.DS_STORE


### PR DESCRIPTION
This is a very small commit that helps developers using Mac OS by reducing clutter in the staging area when committing changes by adding the text `.DS_STORE` to this repository's `.gitignore` file.