### PR TITLE
add missing comma to `snippets.json`

### DIFF
--- a/snippets.json
+++ b/snippets.json
@@ -61,7 +61,7 @@
 			"   });"
 		],
 		"description": "parallelReduce"
-	}
+	},
 	"While Loop": {
 		"prefix": "while",
 		"body": [


### PR DESCRIPTION
This is a very small change that just adds what I think is a missing comma to `snippets.json`.