### PR TITLE
add type dec for `makeLabeledTreeItem`'s arguments

### DIFF
--- a/client/src/CommandsTreeDataProvider.ts
+++ b/client/src/CommandsTreeDataProvider.ts
@@ -12,7 +12,7 @@ const makeTreeItem = (label, command, icon = reach_icon) => {
 	return makeLabeledTreeItem(label, label, command, icon);
 };
 
-const makeLabeledTreeItem = (label, title, command, icon = reach_icon) => {
+const makeLabeledTreeItem = (label: string, title: string, command: string, icon = reach_icon) => {
 	const t : TreeItem = new TreeItem(title, 0);
 	t.command = {
 		command: command,


### PR DESCRIPTION
This is a very small pull request that just adds types to `makeLabeledTreeItem`'s first three parameters.