### PR TITLE
activate extension when workspace has reach file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	},
 	"activationEvents": [
 		"workspaceContains:**/*.rsh",
+		"workspaceContains:reach",
 		"onCommand:reach.compile",
 		"onCommand:reach.run",
 		"onCommand:reach.docs",


### PR DESCRIPTION
This extension should "turn on" when it detects a file with the name "reach" in the current workspace.

This commit accomplishes that by adding `"workspaceContains:reach,"` to `"activationEvents"` in `package.json`.